### PR TITLE
feat: add direct sell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,107 @@
 # Fast Exit Market Maker
 
-## Testnet
+## Endpoints
 
-endpoints:
+### /sellExit
+
+Registers a new fast sell exit.
+
+First, you have to transfer your UTXO to exitHander address on plasma. Then you you call `/sellExit` to notify market maker.
+
+Usage: [Exit.fastSellUtxo and Exit.fastSellAmount helpers](https://github.com/leapdao/leap-core/blob/master/lib/exit.js#L81)
+
+Example payload:
+```
+{
+    "tx": {
+        "value": "0xf43fc2c04ee0000",
+        "color": 0,
+        "hash": "0x76e9032dda4fc2ba6e850754770652783555de7add8b535ae7777a7a7c590f2a",
+        "from": "0xaf0939af286a35dbfab7ded7c777a5f6e8be26a8",
+        "raw": "0x0311b9a0ff624f789a75bbaf72a524b9e49e0ad86f90ecbdce7022c5e3d70273aa6f00fc6abf47a13842d50525030824b1089c57c94e8847cac1d3e4be0deaedf7f69b6e07b7b8a4f1a67111c26c06fff814ef57d8aa82402b20cbac8e6742e6e98ce51b0000000000000000000000000000000000000000000000000f43fc2c04ee000000002c2a3b359edbcfe3c3ac0cd9f9f1349a96c02530",
+        "blockHash": "0x0934854f4fd9fed3ea93ccf64e40ef6251fa3b6a90f4aca10f3e8661bb59ecd8",
+        "blockNumber": 15275,
+        "transactionIndex": 0,
+        "to": "0x2c2a3b359edbcfe3c3ac0cd9f9f1349a96c02530",
+        "gas": "0x0",
+        "gasPrice": "0x0",
+        "nonce": 0,
+        "input": "0x"
+    },
+    "effectiveBlock": 15295,
+    "inputTx": {
+        "value": "1100000000000000000",
+        "color": 0,
+        "hash": "0xb9a0ff624f789a75bbaf72a524b9e49e0ad86f90ecbdce7022c5e3d70273aa6f",
+        "from": "0xaf0939af286A35DBfab7DEd7c777A5F6E8BE26A8",
+        "raw": "0x03124deb9da953e92bea4021a11fdfbb0ca461765eef83f53739927b6625890f095b013193352ecf53c9d2fcda1318ff5662e1447dc7ae8e939502929e0575a30890a04df251c7e4668d710918b866b809be1dbe0c6d205d9283a6a8393d5e59a8952d1c0000000000000000000000000000000000000000000000000f43fc2c04ee00000000af0939af286a35dbfab7ded7c777a5f6e8be26a8000000000000000000000000000000000000000000000030c73c1f9ad0f640000000af0939af286a35dbfab7ded7c777a5f6e8be26a8",
+        "blockHash": "0x0ea374b424a98d92e5fb0cee4da72e5545afaecb22700bdbb74b30e15cf29779",
+        "blockNumber": 15274,
+        "transactionIndex": 0,
+        "to": "0xaf0939af286A35DBfab7DEd7c777A5F6E8BE26A8",
+        "gas": 0,
+        "gasPrice": "0",
+        "nonce": 0,
+        "input": "0x"
+    },
+    "signedData": [
+        "0x000000000000000000000000000000000055de7add8b535ae7777a7a7c590f2a",
+        "0x0000000000000000000000000000000000000000000000000f43fc2c04ee0000",
+        "0x2244868e84c68666224794b55946e971fd6866aa0651c2677907a594258cd08d",
+        "0x3a6f670eeb3fa225465a0bf522f0e9e88402597355c6e1421f0df975ca20c3ee",
+        "0x000000000000000000000000000000000000000000000000000000000000001b"
+    ]
+}
+```
+
+### GET /exits/{account}/{color}
+
+Returns pending exits for given account for a given color. Pending = registered with market maker, but not yet finalized (waiting for a next period to be mined).
+
+### GET /deals
+
+Returns configuration for the market maker: supported markets, balances and MM adress.
+
+Example response:
+
+```
+{
+    "address": "0x83B3525e17F9eAA92dAE3f9924cc333c94C7E98a",
+    "deals": [
+        {
+            "color": 0,
+            "tokenAddr": "0xD2D0F8a6ADfF16C2098101087f9548465EC96C98",
+            "balance": "18352119999999999872",
+            "rate": 980
+        }
+    ]
+}
+```
+
+### POST - /directSell
+
+Request market maker to payout tokens skipping ExitHandler contract. For that you have to supply a txHash of plasma transaction spending from your account ot market maker account. The value of that transaction will be payed out to you on a root network.
+
+Returns: txHash of payout transaction.
+
+Usage example: [burner](https://github.com/leapdao/burner-wallet/pull/65/files#diff-b00b060794e8d5797bffd335bd17e2a1R252)
+
+## Testnet endpoints
+
 ```
   POST - https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/sellExit
   GET - https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/exits/{account}/{color}
   GET - https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/deals
+  POST - https://2nuxsb25he.execute-api.eu-west-1.amazonaws.com/testnet/directSell
+```
+
+## Mainnet endpoints
+
+```
+  POST - https://k238oyefqc.execute-api.eu-west-1.amazonaws.com/mainnet/sellExit
+  GET - https://k238oyefqc.execute-api.eu-west-1.amazonaws.com/mainnet/exits/{account}/{color}
+  GET - https://k238oyefqc.execute-api.eu-west-1.amazonaws.com/mainnet/deals
+  POST - https://k238oyefqc.execute-api.eu-west-1.amazonaws.com/mainnet/directSell
 ```
 
 ## Development
@@ -23,3 +118,27 @@ Testnet:
 ```
 yarn deploy:testnet
 ```
+
+Mainnet:
+```
+yarn deploy:mainnet
+```
+
+## Operations
+
+### Initial setup
+
+Fund market maker address (derived from PRIV_KEY) with Ether and tokens you want to create markets for. Note, that market maker will submit exits to FastExitHandler and thus needs enough ether not only for tx fees, but for exit stake as well.
+
+### Adding new markets / changing market settings
+
+Change MARKET_CONFIG env var (see package.json for examples)
+
+### Troubleshooting
+
+*Logs*
+mainnet exit finalizer: `sls logs -f finalizer -s mainnet` (fastExits)
+mainnet exit manager: `sls logs -f manager -s mainnet` (registering fastExits, processing directSell of sunDai)
+
+*Receipts*
+Hashes for outbound transactions are stored in DynamoDb as well (see `txHash` attribute). For `directSell` (sunDai) it will be a hash of payout tx, for `fastSell` it will be a hash of `startBoughtExit` tx.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:js": "npm run lint:eslint -- . ",
     "start": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls offline -s testnet",
     "deploy:testnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls deploy -s testnet",
-    "deploy:mainnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 2, \"rate\": 1000 } ]' NODE_URL=https://mainnet-node.leapdao.org KMS_KEY_ID=041908e5-0287-431e-b498-7b9d94c38fd8 sls deploy -s mainnet"
+    "deploy:mainnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 2, \"rate\": 1000 } ]' NODE_URL=https://mainnet-node1.leapdao.org KMS_KEY_ID=041908e5-0287-431e-b498-7b9d94c38fd8 sls deploy -s mainnet"
   },
   "devDependencies": {
     "@sucrase/webpack-loader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "lint": "npm run lint:js",
     "lint:eslint": "eslint --fix --ignore-path .gitignore --ignore-pattern internals/scripts",
     "lint:js": "npm run lint:eslint -- . ",
-    "start": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls offline -s testnet",
-    "deploy:testnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls deploy -s testnet"
+    "start": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls offline -s testnet",
+    "deploy:testnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls deploy -s testnet",
+    "deploy:mainnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 2, \"rate\": 1000 } ]' NODE_URL=https://mainnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls deploy -s mainnet"
   },
   "devDependencies": {
     "@sucrase/webpack-loader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:js": "npm run lint:eslint -- . ",
     "start": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls offline -s testnet",
     "deploy:testnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 1, \"rate\": 1000 } ]' NODE_URL=https://testnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls deploy -s testnet",
-    "deploy:mainnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 2, \"rate\": 1000 } ]' NODE_URL=https://mainnet-node.leapdao.org KMS_KEY_ID=93107264-1adb-4a21-a3a5-3e02646f5f88 sls deploy -s mainnet"
+    "deploy:mainnet": "MARKET_CONFIG='[ { \"color\": 0, \"rate\": 980 }, { \"color\": 2, \"rate\": 1000 } ]' NODE_URL=https://mainnet-node.leapdao.org KMS_KEY_ID=041908e5-0287-431e-b498-7b9d94c38fd8 sls deploy -s mainnet"
   },
   "devDependencies": {
     "@sucrase/webpack-loader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsbi-utils": "^1.0.1",
     "leap-core": "^0.28.4",
     "leap-guardian": "^1.2.0",
-    "leap-lambda-boilerplate": "^1.3.0"
+    "leap-lambda-boilerplate": "^1.3.0",
+    "node-fetch": "^2.3.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -152,6 +152,15 @@ functions:
             passThrough: WHEN_NO_TEMPLATES
             template: *request_template
           response: *response_mappings
+      - http:
+          method: post
+          path: /directSell
+          integration: lambda
+          cors: true
+          request:
+            passThrough: WHEN_NO_TEMPLATES
+            template: *request_template
+          response: *response_mappings
 
   finalizer:
     timeout: 30

--- a/serverless.yml
+++ b/serverless.yml
@@ -172,7 +172,7 @@ functions:
       MARKET_CONFIG: ${env:MARKET_CONFIG}
       ENV: ${opt:stage}
     events:
-      - schedule: rate(1 minute)
+      - schedule: rate(3 minutes)
 
 plugins:
   - serverless-webpack

--- a/src/db.js
+++ b/src/db.js
@@ -78,4 +78,29 @@ export default class Db extends DynamoDb {
     return this.query(params);
   }
 
+  addDirectSellRequest(txHash, value, color, account, payoutTxHash) {
+    const params = {
+      TableName: this.tableName,
+      Item: {
+        utxoId: txHash.toLowerCase(),
+        color,
+        account: account.toLowerCase(),
+        value,
+        finalized: 1,
+        txHash: payoutTxHash,
+      },
+    };
+    return this.add(params);
+  }
+
+  getDirectSellRequest(txHash) {
+    const params = {
+      TableName: this.tableName,
+      Key: {
+        utxoId: txHash.toLowerCase(),
+      },
+    };
+    return this.get(params);
+  }
+
 }

--- a/src/db.js
+++ b/src/db.js
@@ -90,6 +90,7 @@ export default class Db extends DynamoDb {
         txHash: payoutTxHash,
       },
     };
+    console.log(params);
     return this.add(params);
   }
 

--- a/src/exitManager/exitManager.js
+++ b/src/exitManager/exitManager.js
@@ -7,16 +7,18 @@
 
 import { Tx } from 'leap-core';
 import { bufferToHex } from 'ethereumjs-util';
+import { bi, lessThan } from 'jsbi-utils';
 
 import getToken from '../common/getToken';
 
 class ExitManager {
 
-  constructor(db, marketConfig, exitHandler, rootWallet) {
+  constructor(db, marketConfig, exitHandler, rootWallet, plasmaWallet) {
     this.db = db;
     this.marketConfig = marketConfig;
     this.exitHandler = exitHandler;
     this.rootWallet = rootWallet;
+    this.plasmaWallet = plasmaWallet;
   }
 
   async registerExit({ body }) {
@@ -39,7 +41,7 @@ class ExitManager {
   }
 
   async getDeals() {
-    return Promise.all(this.marketConfig.map(async (market) => {
+    const deals = await Promise.all(this.marketConfig.map(async (market) => {
       const token = await getToken(market.color, this.exitHandler, this.rootWallet.provider);
       const balance = await token.balanceOf(this.rootWallet.address);
       return {
@@ -49,6 +51,52 @@ class ExitManager {
         rate: market.rate,
       };
     }));
+
+    return {
+      address: this.rootWallet.address,
+      deals,
+    };
+  }
+
+  async directSell({ body }) {
+    const { txHash } = body;
+    console.log('Direct sell request:', txHash);
+
+    const sellRequest = await this.db.getDirectSellRequest(txHash);
+    if (sellRequest) {
+      throw new Error('Wrong tx: already payed out');
+    }
+
+    const { raw } = await this.plasmaWallet.provider.getTransaction(txHash);
+    const tx = Tx.fromRaw(raw);
+    console.log(tx);
+
+    const ourOutput = tx.outputs.find(out => 
+      out.address.toLowerCase() === this.rootWallet.address.toLowerCase()
+    );
+    if (!ourOutput) {
+      throw new Error('Wrong tx: not sending to market maker');
+    }
+
+    const { color, value } = ourOutput;
+
+    const market = this.marketConfig.find(m => m.color === color);
+    if (!market) {
+      throw new Error('No market for color', color);
+    }
+
+    const token = await getToken(color, this.exitHandler, this.rootWallet);
+    const balance = await token.balanceOf(this.rootWallet.address);
+    if (lessThan(bi(balance), value)) {
+      throw new Error('Not enough tokens on the market');
+    }
+
+    const account = tx.inputs[0].signer;
+
+    const payoutTx = await token.transfer(account, value.toString());
+    console.log('Direct sell payout:', payoutTx);
+    await this.db.addDirectSellRequest(txHash, value, color, account, payoutTx.hash);
+    return payoutTx.hash;
   }
 }
 

--- a/src/exitManager/exitManager.js
+++ b/src/exitManager/exitManager.js
@@ -72,8 +72,8 @@ class ExitManager {
     const tx = Tx.fromRaw(raw);
     console.log(tx);
 
-    const ourOutput = tx.outputs.find(out => 
-      out.address.toLowerCase() === this.rootWallet.address.toLowerCase()
+    const ourOutput = tx.outputs.find(out =>
+      out.address.toLowerCase() === this.rootWallet.address.toLowerCase(),
     );
     if (!ourOutput) {
       throw new Error('Wrong tx: not sending to market maker');

--- a/src/exitManager/index.js
+++ b/src/exitManager/index.js
@@ -13,8 +13,6 @@ import { exitHandlerAbi } from 'leap-guardian/abis';
 import ExitManager from './exitManager';
 import Db from '../db';
 
-let exitManager;
-
 exports.handler = async (event) => {
   const path = event.context['resource-path'];
   const method = event.context['http-method'];
@@ -22,22 +20,19 @@ exports.handler = async (event) => {
   const tableName = process.env.TABLE_NAME;
   const nodeUrl = process.env.NODE_URL;
   const privKey = await Properties.readEncrypted(`/exit-market/${process.env.ENV}/PRIV_KEY`);
-
   const marketConfig = JSON.parse(process.env.MARKET_CONFIG);
 
-  if (!exitManager) {
-    const { rootWallet, plasmaWallet, nodeConfig } = await wallet({ nodeUrl, privKey });
-    const { exitHandlerAddr } = nodeConfig;
-    const exitHandler = new ethers.Contract(exitHandlerAddr, exitHandlerAbi, rootWallet);
+  const { rootWallet, plasmaWallet, nodeConfig } = await wallet({ nodeUrl, privKey });
+  const { exitHandlerAddr } = nodeConfig;
+  const exitHandler = new ethers.Contract(exitHandlerAddr, exitHandlerAbi, rootWallet);
 
-    exitManager = new ExitManager(
-      new Db(tableName),
-      marketConfig,
-      exitHandler,
-      rootWallet,
-      plasmaWallet,
-    );
-  }
+  const exitManager = new ExitManager(
+    new Db(tableName),
+    marketConfig,
+    exitHandler,
+    rootWallet,
+    plasmaWallet,
+  );
 
   const router = new Router([
     ['POST', '/sellExit', exitManager.registerExit.bind(exitManager)],

--- a/src/exitManager/index.js
+++ b/src/exitManager/index.js
@@ -26,7 +26,7 @@ exports.handler = async (event) => {
   const marketConfig = JSON.parse(process.env.MARKET_CONFIG);
 
   if (!exitManager) {
-    const { rootWallet, nodeConfig } = await wallet({ nodeUrl, privKey });
+    const { rootWallet, plasmaWallet, nodeConfig } = await wallet({ nodeUrl, privKey });
     const { exitHandlerAddr } = nodeConfig;
     const exitHandler = new ethers.Contract(exitHandlerAddr, exitHandlerAbi, rootWallet);
 
@@ -35,6 +35,7 @@ exports.handler = async (event) => {
       marketConfig,
       exitHandler,
       rootWallet,
+      plasmaWallet,
     );
   }
 
@@ -42,6 +43,7 @@ exports.handler = async (event) => {
     ['POST', '/sellExit', exitManager.registerExit.bind(exitManager)],
     ['GET', '/exits/:account', exitManager.getAccountExits.bind(exitManager)],
     ['GET', '/deals', exitManager.getDeals.bind(exitManager)],
+    ['POST', '/directSell', exitManager.directSell.bind(exitManager)],
   ]);
 
   return router.dispatch(method, path, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3642,6 +3642,11 @@ nigel@2.x.x:
     hoek "4.x.x"
     vise "2.x.x"
 
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 node-libs-browser@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"


### PR DESCRIPTION
Given:
- user with plasma tokens wants to fast exit them

Flow:
- user queries /deals endpoint to see if there is a market and liquidity for a given token
- if user decides to proceed, he transfers his tokens to market maker address on plasma. Address is provided by /deals endpoint as well
- user does POST /directSell with { txHash } payload. Market maker should check given tx and payout the user on the root network. Endpoint returns txHash of the payout
- (optionally, for sunDai) user waits for payout tx to mine and executes `burnSender` to get his DAI on the root network

Market maker performs the following checks on provided txHash:
- should be included in a block
- should not be payed out already
- should spend to market maker address
- market should exit for the color in tx
- balance for the token should be enough for payout

Payout rules:
- payout goes to the signer of the tx input
- payout amount is the value of the first output to market maker.