### PR TITLE
feat: support any slotId for periods

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ethereumjs-util": "^6.0.0",
     "ethers": "^4.0.27",
     "jsbi-utils": "^1.0.1",
-    "leap-core": "^0.28.4",
+    "leap-core": "^0.35.0",
     "leap-guardian": "^1.2.0",
     "leap-lambda-boilerplate": "^1.3.0",
     "node-fetch": "^2.3.0"

--- a/src/exitFinalizer/exitFinalizer.js
+++ b/src/exitFinalizer/exitFinalizer.js
@@ -60,8 +60,6 @@ class ExitFinalizer {
 
   async sellExit(exit) {
     console.log('Finalizing fast exit', exit);
-    const slotId = 0; // TODO: any slot
-    const { signer } = await this.operator.slots(slotId);
 
     const { inputTx, signedData } = exit.data;
     const exitingTx = exit.data.tx;
@@ -72,8 +70,8 @@ class ExitFinalizer {
       getBlock: (num, includeTxs) =>
         this.plasma.send('eth_getBlockByNumber', [num, includeTxs]),
     };
-    const txProof = await getProof(blockProvider, exitingTx, 0, signer);
-    const inputProof = await getProof(blockProvider, inputTx, 0, signer);
+    const txProof = await getProof(blockProvider, exitingTx);
+    const inputProof = await getProof(blockProvider, inputTx);
 
     const outputIndex = 0;
     const inputIndex = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,7 +3185,7 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leap-core@^0.28.1, leap-core@^0.28.4:
+leap-core@^0.28.1:
   version "0.28.4"
   resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.28.4.tgz#fabe3609ec1d19cbeebf96f3a030de070cc49969"
   integrity sha512-qMWhAL+3//2rllZJr6XOJI+zb3SPXiGOjk3GoUJJG049zCt+csxKUHfqfOjTNEBnvwzfZCBRZnAg82coOXsikQ==
@@ -3194,6 +3194,16 @@ leap-core@^0.28.1, leap-core@^0.28.4:
     babel-polyfill "^6.26.0"
     ethereumjs-util "6.0.0"
     jsbi-utils "^1.0.0"
+
+leap-core@^0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.35.0.tgz#89d5a470a37a355a843647840a3f6ffdd5a99f79"
+  integrity sha512-q8VKCXtbFVCUEkAbQp4YE+8aZ8lxXc9zOQGxwZ2M/6eRysXVzloywcD7/T2zJG+nvaw4xg7+kGxgaDEiaZrORA==
+  dependencies:
+    "@types/web3" "^1.0.18"
+    ethereumjs-util "6.0.0"
+    jsbi-utils "^1.0.0"
+    node-fetch "^2.3.0"
 
 leap-guardian@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Requires updated leap-core: https://github.com/leapdao/leap-core/pull/134

All the heavy lifting done on the leap-core side: it fetches the period data from the node's period store

Resolves #9 
