### PR TITLE
feat: check if period is submitted before submitting fast exit

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -163,7 +163,7 @@ functions:
           response: *response_mappings
 
   finalizer:
-    timeout: 30
+    timeout: 120
     handler: src/exitFinalizer/index.handler
     name: exit-market-${opt:stage}-finalizer
     environment:

--- a/src/exitFinalizer/exitFinalizer.js
+++ b/src/exitFinalizer/exitFinalizer.js
@@ -17,11 +17,16 @@ const { getProof } = helpers;
 const { BadRequest, ServerError } = Errors;
 
 class ExitFinalizer {
+<<<<<<< HEAD
   constructor(rate, senderAddr, exitHandler, operator, root, plasma, db, marketConfig) {
+=======
+  constructor(rate, senderAddr, exitHandler, operator, bridge, root, plasma, db, marketConfig) {
+>>>>>>> feat: check if period is submitted before submitting fast exit
     this.rate = rate;
     this.senderAddr = senderAddr;
     this.exitHandler = exitHandler;
     this.operator = operator;
+    this.bridge = bridge;
     this.db = db;
     this.root = root;
     this.plasma = plasma;
@@ -76,6 +81,12 @@ class ExitFinalizer {
     const fallbackPeriodData = { slotId, validatorAddress: signer };
 
     const txProof = await getProof(this.plasma, exitingTx, fallbackPeriodData);
+
+    const [height] = await this.bridge.periods(txProof[0]);
+    if (!height) {
+      throw new Error('Period for exiting tx is not submitted yet');
+    }
+
     const inputProof = await getProof(this.plasma, inputTx, fallbackPeriodData);
 
     const outputIndex = 0;

--- a/src/exitFinalizer/index.js
+++ b/src/exitFinalizer/index.js
@@ -10,7 +10,7 @@ import { ethers } from 'ethers';
 import { Properties } from 'leap-lambda-boilerplate';
 
 import wallet from 'leap-guardian/scripts/utils/wallet';
-import { operatorAbi, exitHandlerAbi } from 'leap-guardian/abis';
+import { operatorAbi, exitHandlerAbi, bridgeAbi } from 'leap-guardian/abis';
 
 import ExitFinalizer from './exitFinalizer';
 import Db from '../db';
@@ -28,15 +28,17 @@ exports.handler = async () => {
 
   if (!finalizer) {
     const { plasmaWallet, rootWallet, nodeConfig } = await wallet({ nodeUrl, privKey });
-    const { exitHandlerAddr, operatorAddr } = nodeConfig;
+    const { exitHandlerAddr, operatorAddr, bridgeAddr } = nodeConfig;
     const exitHandler = new ethers.Contract(exitHandlerAddr, exitHandlerAbi, rootWallet);
     const operator = new ethers.Contract(operatorAddr, operatorAbi, rootWallet);
+    const bridge = new ethers.Contract(bridgeAddr, bridgeAbi, rootWallet);
 
     finalizer = new ExitFinalizer(
       rate,
       handlerAddr,
       exitHandler,
       operator,
+      bridge,
       rootWallet,
       plasmaWallet.provider,
       new Db(tableName),


### PR DESCRIPTION
- [x] increased lambda timeout to 2 minutes. temporary workaround to allow processing a few exits at a time. Proper fix would be not to wait on txs being mined and process exits in batches
- [x] before submitting a fast exit to the exitHandler, we check the bridge if it has the period from the proof. This way we prevent failed txs — since CAS we cannot rely on block height for period expectancy anymore. 